### PR TITLE
Typo: "on on" -> "on" in the footnote

### DIFF
--- a/_posts/blog/2016-07-18-what-is-variational-autoencoder-vae-tutorial.md
+++ b/_posts/blog/2016-07-18-what-is-variational-autoencoder-vae-tutorial.md
@@ -231,7 +231,7 @@ For some distributions, it is possible to reparametrize samples in a clever way,
 
 $$ z = \mu + \sigma \odot \epsilon, $$
 
-where $$ \epsilon \sim Normal(0, 1) $$. Going from $$ \sim $$ denoting a draw from the distribution to the equals sign $$ = $$ is the crucial step. We have defined a function that depends on on the parameters deterministically. We can thus take derivatives of functions involving $$ z $$, $$f(z)$$ with respect to the parameters of its distribution $$ \mu $$ and $$ \sigma $$.
+where $$ \epsilon \sim Normal(0, 1) $$. Going from $$ \sim $$ denoting a draw from the distribution to the equals sign $$ = $$ is the crucial step. We have defined a function that depends on the parameters deterministically. We can thus take derivatives of functions involving $$ z $$, $$f(z)$$ with respect to the parameters of its distribution $$ \mu $$ and $$ \sigma $$.
 
 <figure>
     <img src="/images/reparametrization.png">


### PR DESCRIPTION
In the "Footnote: the reparametrization trick" section, there's a small typo "on on".